### PR TITLE
HW02 kubernetes-controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,46 @@
-# sergetol_platform
+# sergetol_platform [![Run tests for OTUS homework](https://github.com/otus-kuber-2021-12/sergetol_platform/actions/workflows/run-tests.yml/badge.svg)](https://github.com/otus-kuber-2021-12/sergetol_platform/actions/workflows/run-tests.yml)
+## [OTUS - Инфраструктурная платформа на основе Kubernetes](https://otus.ru/lessons/infrastrukturnaya-platforma-na-osnove-kubernetes/)
 sergetol Platform repository
+
+
+# HW02 (kubernetes-controllers)
+
+- поднят k8s кластер с помощью `kind` согласно конфигурации kind-config.yaml
+- задеплоен `frontend-replicaset.yaml` для приложения `frontend`, проведен эксперимент с изменением количества реплик
+- собрано еще раз приложение `frontend` с новым тегом `1.0.1` (был `1.0.0`); после применения манифеста ReplicaSet с новым тегом образа поды остались работать на старом образе, потому как ReplicaSet следит лишь за их количеством, а оно совпадало с требуемым, но если удалить поды, то они уже поднимутся на новом образе, либо тут надо использовать Deployment
+- собрано приложение `paymentservice` с тегами `v0.0.1` и `v0.0.2`; написан `paymentservice-replicaset.yaml`, проведен тот же эксперимент с изменением количества реплик и новым тегом образа
+- написан `paymentservice-deployment.yaml`, проведены эсперименты с RollingUpdate
+- (*) написаны `paymentservice-deployment-bg.yaml` и `paymentservice-deployment-reverse.yaml` для blue-green и reverse RollingUpdate деплоя соответственно
+- написан `frontend-deployment.yaml` с описанием readinessProbe для приложения `frontend`
+- (*) написан `node-exporter-daemonset.yaml`
+- (**) чтобы поды `node-exporter` смогли запускаться и на master нодах, в `node-exporter-daemonset.yaml` добавлено соответствующее toleration условие
+
+```
+cd kubernetes-controllers
+
+kind create cluster --config kind-config.yaml
+# kubectl get nodes
+
+kubectl apply -f paymentservice-deployment.yaml
+kubectl apply -f frontend-deployment.yaml
+
+# kubectl get deployments
+# kubectl get rs
+# kubectl get pods
+
+# kubectl delete -f paymentservice-deployment.yaml
+# kubectl delete -f frontend-deployment.yaml
+
+kubectl apply -f node-exporter-daemonset.yaml
+
+# kubectl port-forward <daemonset_any_pod_name> 9100:9100
+# http://localhost:9100/metrics
+
+kubectl delete -f node-exporter-daemonset.yaml
+
+kind delete cluster
+```
+
 
 # HW01 (kubernetes-intro)
 

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: sergetol/demo-frontend:1.0.1  # 1.0.0
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+          httpGet:
+            port: 8080
+            path: "/_healthz"
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "dummy"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "dummy"
+        - name: CART_SERVICE_ADDR
+          value: "dummy"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "dummy"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "dummy"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "dummy"
+        - name: AD_SERVICE_ADDR
+          value: "dummy"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: sergetol/demo-frontend:1.0.1  # 1.0.0
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "dummy"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "dummy"
+        - name: CART_SERVICE_ADDR
+          value: "dummy"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "dummy"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "dummy"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "dummy"
+        - name: AD_SERVICE_ADDR
+          value: "dummy"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/kind-config.yaml
+++ b/kubernetes-controllers/kind-config.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  labels:
+    name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      name: node-exporter
+  template:
+    metadata:
+      labels:
+        name: node-exporter
+      annotations:
+         prometheus.io/scrape: "true"
+         prometheus.io/port: "9100"
+    spec:
+      tolerations:
+      # this toleration is to have the daemonset runnable on master nodes
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      volumes:
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: root
+        hostPath:
+          path: /
+      containers:
+      - name: node-exporter
+        image: prom/node-exporter:v1.3.1
+        securityContext:
+          privileged: true
+        args:
+        - "--path.procfs=/host/proc"
+        - "--path.sysfs=/host/sys"
+        - "--path.rootfs=/host/root"
+        ports:
+        - containerPort: 9100
+        resources:
+          limits:
+            cpu: 300m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: proc
+          mountPath: /host/proc
+        - name: sys
+          mountPath: /host/sys
+        - name: root
+          mountPath: /host/root
+          readOnly: true

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: sergetol/demo-paymentservice:v0.0.2  # v0.0.1
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: sergetol/demo-paymentservice:v0.0.2  # v0.0.1
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: sergetol/demo-paymentservice:v0.0.2  # v0.0.1
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: sergetol/demo-paymentservice:v0.0.1  # v0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"


### PR DESCRIPTION
# Выполнено ДЗ №02 (kubernetes-controllers)

 - [x] Основное ДЗ
 - [x] Задание со *
 - [x] Задание с **

## В процессе сделано:
- поднят k8s кластер с помощью `kind` согласно конфигурации kind-config.yaml
- задеплоен `frontend-replicaset.yaml` для приложения `frontend`, проведен эксперимент с изменением количества реплик
- собрано еще раз приложение `frontend` с новым тегом `1.0.1` (был `1.0.0`); после применения манифеста ReplicaSet с новым тегом образа поды остались работать на старом образе, потому как ReplicaSet следит лишь за их количеством, а оно совпадало с требуемым, но если удалить поды, то они уже поднимутся на новом образе, либо тут надо использовать Deployment
- собрано приложение `paymentservice` с тегами `v0.0.1` и `v0.0.2`; написан `paymentservice-replicaset.yaml`, проведен тот же эксперимент с изменением количества реплик и новым тегом образа
- написан `paymentservice-deployment.yaml`, проведены эсперименты с RollingUpdate
- (*) написаны `paymentservice-deployment-bg.yaml` и `paymentservice-deployment-reverse.yaml` для blue-green и reverse RollingUpdate деплоя соответственно
- написан `frontend-deployment.yaml` с описанием readinessProbe для приложения `frontend`
- (*) написан `node-exporter-daemonset.yaml`
- (**) чтобы поды `node-exporter` смогли запускаться и на master нодах, в `node-exporter-daemonset.yaml` добавлено соответствующее toleration условие

## Как запустить проект:
```
cd kubernetes-controllers
kind create cluster --config kind-config.yaml
kubectl apply -f paymentservice-deployment.yaml
kubectl apply -f frontend-deployment.yaml
kubectl apply -f node-exporter-daemonset.yaml
kind delete cluster
```

## Как проверить работоспособность:
```
kubectl get deployments
kubectl get rs
kubectl get pods
kubectl port-forward <daemonset_any_pod_name> 9100:9100
# перейти по ссылке http://localhost:9100/metrics
```

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
